### PR TITLE
allow og:image instead of og:image:url

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -77,7 +77,7 @@ abstract class Type extends BaseObject
      */
     public function image($image)
     {
-        if($image instanceof Image) {
+        if ($image instanceof Image) {
             $this->addStructuredProperty($image);
 
             return $this;
@@ -94,7 +94,7 @@ abstract class Type extends BaseObject
      */
     public function video($video)
     {
-        if($video instanceof Video) {
+        if ($video instanceof Video) {
             $this->addStructuredProperty($video);
 
             return $this;
@@ -111,7 +111,7 @@ abstract class Type extends BaseObject
      */
     public function audio($audio)
     {
-        if($audio instanceof Audio) {
+        if ($audio instanceof Audio) {
             $this->addStructuredProperty($audio);
 
             return $this;

--- a/src/Type.php
+++ b/src/Type.php
@@ -77,11 +77,13 @@ abstract class Type extends BaseObject
      */
     public function image($image)
     {
-        $this->addStructuredProperty(
-            $image instanceof Image
-                ? $image
-                : Image::make($image)
-        );
+        if($image instanceof Image) {
+            $this->addStructuredProperty($image);
+
+            return $this;
+        }
+
+        $this->addProperty('og', 'image', $image);
 
         return $this;
     }
@@ -92,11 +94,13 @@ abstract class Type extends BaseObject
      */
     public function video($video)
     {
-        $this->addStructuredProperty(
-            $video instanceof Video
-                ? $video
-                : Video::make($video)
-        );
+        if($video instanceof Video) {
+            $this->addStructuredProperty($video);
+
+            return $this;
+        }
+
+        $this->addProperty('og', 'video', $video);
 
         return $this;
     }
@@ -107,11 +111,13 @@ abstract class Type extends BaseObject
      */
     public function audio($audio)
     {
-        $this->addStructuredProperty(
-            $audio instanceof Audio
-                ? $audio
-                : Audio::make($audio)
-        );
+        if($audio instanceof Audio) {
+            $this->addStructuredProperty($audio);
+
+            return $this;
+        }
+
+        $this->addProperty('og', 'audio', $audio);
 
         return $this;
     }

--- a/tests/GlobalTypesTest.php
+++ b/tests/GlobalTypesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Astrotomic\OpenGraph\StructuredProperties\Audio;
 use Astrotomic\OpenGraph\Types\Article;
 use Astrotomic\OpenGraph\Types\Book;
 use Astrotomic\OpenGraph\Types\Profile;
@@ -68,6 +69,10 @@ it('can generate article tags', function () {
         ->alternateLocale('en_GB')
         ->siteName('Example')
         ->image('http://www.example.com/image1.jpg')
+        ->audio(
+            Audio::make('http://www.example.com/audio.mp3')
+                ->mimeType('audio/mp3')
+        )
 
         ->publishedAt(new DateTime('2020-06-05 20:00:00'))
         ->modifiedAt(new DateTime('2020-06-07 20:00:00'))

--- a/tests/VideoTypesTest.php
+++ b/tests/VideoTypesTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Astrotomic\OpenGraph\StructuredProperties\Image;
+use Astrotomic\OpenGraph\StructuredProperties\Video;
 use Astrotomic\OpenGraph\Types\Video\Episode;
 use Astrotomic\OpenGraph\Types\Video\Movie;
 use Astrotomic\OpenGraph\Types\Video\Other;
@@ -21,6 +22,7 @@ it('can generate movie tags', function () {
                 ->mimeType('image/jpg')
                 ->alt('Movie Wallpaper')
         )
+        ->video('http://www.example.com/trailer.mp4')
 
         ->releasedAt(new DateTime('2020-06-05'))
         ->actor('http://www.example.com/actor1', 'role1')
@@ -80,7 +82,13 @@ it('can generate other tags', function () {
         ->alternateLocale('en_GB')
         ->siteName('Example')
         ->image('http://www.example.com/image1.jpg')
-        ->video('http://www.example.com/video.mp4')
+        ->video(
+            Video::make('http://www.example.com/video.mp4')
+                ->width(1920)
+                ->height(1080)
+                ->mimeType('video/mp4')
+                ->alt('Movie Wallpaper')
+        )
 
         ->releasedAt(new DateTime('2020-06-05'))
         ->duration(60 * 3.5)

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_article_tags__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_article_tags__1.html
@@ -7,7 +7,9 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
+<meta property="og:audio:url" content="http://www.example.com/audio.mp3">
+<meta property="og:audio:type" content="audio/mp3">
 <meta property="article:published_time" content="2020-06-05T20:00:00+0000">
 <meta property="article:modified_time" content="2020-06-07T20:00:00+0000">
 <meta property="article:author" content="http://www.example.com/author">

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_book_tags__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_book_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="book:release_date" content="2020-06-05">
 <meta property="book:isbn" content="978-3-86680-192-9">
 <meta property="book:author" content="http://www.example.com/author">

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_profile_tags__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_profile_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="profile:first_name" content="Jane">
 <meta property="profile:last_name" content="Doe">
 <meta property="profile:username" content="janedoe">

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags__1.html
@@ -7,5 +7,5 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 </head></html>

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_conditional_callbacks__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_conditional_callbacks__1.html
@@ -7,5 +7,5 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 </head></html>

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_conditional_proxies__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_conditional_proxies__1.html
@@ -7,5 +7,5 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 </head></html>

--- a/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_stringable_image__1.html
+++ b/tests/__snapshots__/GlobalTypesTest__it_can_generate_website_tags_with_stringable_image__1.html
@@ -7,5 +7,5 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 </head></html>

--- a/tests/__snapshots__/MusicTypesTest__it_can_generate_album_tags__1.html
+++ b/tests/__snapshots__/MusicTypesTest__it_can_generate_album_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="music:musician" content="http://www.example.com/musician">
 <meta property="music:song" content="http://www.example.com/song1">
 <meta property="music:song:disc" content="1">

--- a/tests/__snapshots__/MusicTypesTest__it_can_generate_playlist_tags__1.html
+++ b/tests/__snapshots__/MusicTypesTest__it_can_generate_playlist_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="music:creator" content="http://www.example.com/creator">
 <meta property="music:song" content="http://www.example.com/song1">
 <meta property="music:song:disc" content="1">

--- a/tests/__snapshots__/MusicTypesTest__it_can_generate_radiostation_tags__1.html
+++ b/tests/__snapshots__/MusicTypesTest__it_can_generate_radiostation_tags__1.html
@@ -7,6 +7,6 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="music:creator" content="http://www.example.com/creator">
 </head></html>

--- a/tests/__snapshots__/MusicTypesTest__it_can_generate_song_tags__1.html
+++ b/tests/__snapshots__/MusicTypesTest__it_can_generate_song_tags__1.html
@@ -7,8 +7,8 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
-<meta property="og:audio:url" content="http://www.example.com/song.mp3">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
+<meta property="og:audio" content="http://www.example.com/song.mp3">
 <meta property="music:duration" content="90">
 <meta property="music:musician" content="http://www.example.com/musician">
 <meta property="music:album" content="http://www.example.com/album">

--- a/tests/__snapshots__/VideoTypesTest__it_can_generate_episode_tags__1.html
+++ b/tests/__snapshots__/VideoTypesTest__it_can_generate_episode_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="video:series" content="http://www.example.com/tvshow">
 <meta property="video:release_date" content="2020-06-05">
 <meta property="video:duration" content="1500">

--- a/tests/__snapshots__/VideoTypesTest__it_can_generate_movie_tags__1.html
+++ b/tests/__snapshots__/VideoTypesTest__it_can_generate_movie_tags__1.html
@@ -7,12 +7,13 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="og:image:url" content="http://www.example.com/image2.jpg">
 <meta property="og:image:width" content="1920">
 <meta property="og:image:height" content="1080">
 <meta property="og:image:type" content="image/jpg">
 <meta property="og:image:alt" content="Movie Wallpaper">
+<meta property="og:video" content="http://www.example.com/trailer.mp4">
 <meta property="video:release_date" content="2020-06-05">
 <meta property="video:actor" content="http://www.example.com/actor1">
 <meta property="video:actor:role" content="role1">

--- a/tests/__snapshots__/VideoTypesTest__it_can_generate_other_tags__1.html
+++ b/tests/__snapshots__/VideoTypesTest__it_can_generate_other_tags__1.html
@@ -7,8 +7,12 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="og:video:url" content="http://www.example.com/video.mp4">
+<meta property="og:video:width" content="1920">
+<meta property="og:video:height" content="1080">
+<meta property="og:video:type" content="video/mp4">
+<meta property="og:video:alt" content="Movie Wallpaper">
 <meta property="video:release_date" content="2020-06-05">
 <meta property="video:duration" content="210">
 <meta property="video:actor" content="http://www.example.com/actor">

--- a/tests/__snapshots__/VideoTypesTest__it_can_generate_tv_show_tags__1.html
+++ b/tests/__snapshots__/VideoTypesTest__it_can_generate_tv_show_tags__1.html
@@ -7,7 +7,7 @@
 <meta property="og:locale" content="en_US">
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
-<meta property="og:image:url" content="http://www.example.com/image1.jpg">
+<meta property="og:image" content="http://www.example.com/image1.jpg">
 <meta property="video:release_date" content="2020-06-05">
 <meta property="video:actor" content="http://www.example.com/actor">
 <meta property="video:actor:role" content="role">


### PR DESCRIPTION
This changes the behavior if a simple string is passed in.
Before always the `og:image:url` was used - now the simpler `og:image` is used if a simple string is passed in. Same for audio and video.
Thanks @ben221199 for the idea!
replaces #4 