### PR TITLE
Change property og:image:url to og:image

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ echo OpenGraph::website('Example')
 <meta property="og:type" content="website" />
 <meta property="og:title" content="Example" />
 <meta property="og:url" content="https://example.com" />
-<meta property="og:image:url" content="https://example.com/image1.jpg" />
-<meta property="og:image:url" content="https://example.com/image2.jpg" />
+<meta property="og:image" content="https://example.com/image1.jpg" />
+<meta property="og:image" content="https://example.com/image2.jpg" />
 <meta property="og:image:width" content="600" />
 ```
 

--- a/src/BaseObject.php
+++ b/src/BaseObject.php
@@ -11,9 +11,10 @@ abstract class BaseObject
     /** @var BaseObject[] */
     protected $tags = [];
 
-    public function setProperty(string $prefix, string $property, string $content)
+    public function setProperty(string $prefix, ?string $property, string $content)
     {
-        $this->tags[$prefix.':'.$property] = Property::make($prefix, $property, $content);
+        $key = $property ? $prefix.':'.$property : $prefix;
+        $this->tags[$key] = Property::make($prefix, $property, $content);
     }
 
     public function addProperty(string $prefix, string $property, string $content)

--- a/src/Property.php
+++ b/src/Property.php
@@ -7,26 +7,28 @@ class Property
     /** @var string */
     protected $prefix = 'og';
 
-    /** @var string */
+    /** @var string|null */
     protected $property;
 
     /** @var string */
     protected $content;
 
-    public function __construct(string $prefix, string $property, string $content)
+    public function __construct(string $prefix, ?string $property, string $content)
     {
         $this->prefix = $prefix;
         $this->property = $property;
         $this->content = $content;
     }
 
-    public static function make(string $prefix, string $property, string $content)
+    public static function make(string $prefix, ?string $property, string $content)
     {
         return new static($prefix, $property, $content);
     }
 
     public function __toString(): string
     {
-        return "<meta property=\"{$this->prefix}:{$this->property}\" content=\"{$this->content}\">";
+        $property = $this->property ? "$this->prefix:$this->property" : $this->prefix;
+
+        return "<meta property=\"{$property}\" content=\"{$this->content}\">";
     }
 }

--- a/src/StructuredProperties/Image.php
+++ b/src/StructuredProperties/Image.php
@@ -10,7 +10,7 @@ class Image extends BaseObject
 
     public function __construct(string $url)
     {
-        $this->setProperty(self::PREFIX, 'url', $url);
+        $this->setProperty(self::PREFIX, null, $url);
     }
 
     public static function make(string $url)

--- a/tests/__snapshots__/VideoTypesTest__it_can_generate_movie_tags__1.html
+++ b/tests/__snapshots__/VideoTypesTest__it_can_generate_movie_tags__1.html
@@ -8,7 +8,7 @@
 <meta property="og:locale:alternate" content="en_GB">
 <meta property="og:site_name" content="Example">
 <meta property="og:image" content="http://www.example.com/image1.jpg">
-<meta property="og:image:url" content="http://www.example.com/image2.jpg">
+<meta property="og:image" content="http://www.example.com/image2.jpg">
 <meta property="og:image:width" content="1920">
 <meta property="og:image:height" content="1080">
 <meta property="og:image:type" content="image/jpg">


### PR DESCRIPTION
The spec allows both but popular messenger prefer the property without `:url`

Every messenger i tested ignored the property `og:image:url` and only used `og:image`.

Tested Messengers:

* Telegram
* Rocket.Chat
* Riot/Element
* Facebook