### PR TITLE
fix: Changes property to name for twitter cards

### DIFF
--- a/src/TwitterBaseObject.php
+++ b/src/TwitterBaseObject.php
@@ -8,7 +8,7 @@ abstract class TwitterBaseObject
 {
     use HasConditionalCalls;
 
-    /** @var BaseObject[] */
+    /** @var TwitterBaseObject[] */
     protected $tags = [];
 
     public function setName(string $prefix, string $name, string $content)

--- a/src/TwitterBaseObject.php
+++ b/src/TwitterBaseObject.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Astrotomic\OpenGraph;
+
+use Astrotomic\ConditionalProxy\HasConditionalCalls;
+
+abstract class TwitterBaseObject
+{
+    use HasConditionalCalls;
+
+    /** @var BaseObject[] */
+    protected $tags = [];
+
+    public function setName(string $prefix, string $name, string $content)
+    {
+        $this->tags[$prefix.':'.$name] = TwitterName::make($prefix, $name, $content);
+    }
+
+    public function __toString(): string
+    {
+        return implode(PHP_EOL, array_map('strval', $this->tags));
+    }
+}

--- a/src/TwitterName.php
+++ b/src/TwitterName.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Astrotomic\OpenGraph;
+
+class TwitterName
+{
+    /** @var string */
+    protected $prefix = 'twitter';
+
+    /** @var string */
+    protected $name;
+
+    /** @var string */
+    protected $content;
+
+    public function __construct(string $prefix, string $name, string $content)
+    {
+        $this->prefix = $prefix;
+        $this->name = $name;
+        $this->content = $content;
+    }
+
+    public static function make(string $prefix, string $name, string $content)
+    {
+        return new static($prefix, $name, $content);
+    }
+
+    public function __toString(): string
+    {
+        $content = str_replace('"', '&quot;', $this->content);
+
+        return "<meta name=\"{$this->prefix}:{$this->name}\" content=\"{$content}\">";
+    }
+}

--- a/src/TwitterType.php
+++ b/src/TwitterType.php
@@ -2,13 +2,13 @@
 
 namespace Astrotomic\OpenGraph;
 
-abstract class TwitterType extends BaseObject
+abstract class TwitterType extends TwitterBaseObject
 {
     protected const PREFIX = 'twitter';
 
     public function __construct(?string $title = null)
     {
-        $this->setProperty(self::PREFIX, 'card', $this->type);
+        $this->setName(self::PREFIX, 'card', $this->type);
         $this->when($title)->title($title);
     }
 
@@ -19,29 +19,29 @@ abstract class TwitterType extends BaseObject
 
     public function title(string $title)
     {
-        $this->setProperty(self::PREFIX, 'title', $title);
+        $this->setName(self::PREFIX, 'title', $title);
 
         return $this;
     }
 
     public function site(string $site)
     {
-        $this->setProperty(self::PREFIX, 'site', $site);
+        $this->setName(self::PREFIX, 'site', $site);
 
         return $this;
     }
 
     public function description(string $description)
     {
-        $this->setProperty(self::PREFIX, 'description', $description);
+        $this->setName(self::PREFIX, 'description', $description);
 
         return $this;
     }
 
     public function image(string $image, ?string $alt = null)
     {
-        $this->setProperty(self::PREFIX, 'image', $image);
-        $this->when($alt)->setProperty(self::PREFIX, 'image:alt', $alt);
+        $this->setName(self::PREFIX, 'image', $image);
+        $this->when($alt)->setName(self::PREFIX, 'image:alt', $alt);
 
         return $this;
     }

--- a/src/Types/Twitter/Player.php
+++ b/src/Types/Twitter/Player.php
@@ -11,9 +11,9 @@ class Player extends TwitterType
 
     public function player(string $url, int $width, int $height)
     {
-        $this->setProperty(self::PREFIX, 'player', $url);
-        $this->setProperty(self::PREFIX, 'player:width', $width);
-        $this->setProperty(self::PREFIX, 'player:height', $height);
+        $this->setName(self::PREFIX, 'player', $url);
+        $this->setName(self::PREFIX, 'player:width', $width);
+        $this->setName(self::PREFIX, 'player:height', $height);
 
         return $this;
     }

--- a/src/Types/Twitter/SummaryLargeImage.php
+++ b/src/Types/Twitter/SummaryLargeImage.php
@@ -11,7 +11,7 @@ class SummaryLargeImage extends TwitterType
 
     public function creator(string $creator)
     {
-        $this->setProperty(self::PREFIX, 'creator', $creator);
+        $this->setName(self::PREFIX, 'creator', $creator);
 
         return $this;
     }

--- a/tests/__snapshots__/TwitterTypesTest__it_can_generate_player_tags__1.html
+++ b/tests/__snapshots__/TwitterTypesTest__it_can_generate_player_tags__1.html
@@ -1,12 +1,12 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><head>
-<meta property="twitter:card" content="player">
-<meta property="twitter:title" content="Title | Example">
-<meta property="twitter:description" content="Description">
-<meta property="twitter:site" content="@astrotomic_oss">
-<meta property="twitter:image" content="http://www.example.com/image1.jpg">
-<meta property="twitter:image:alt" content="Image alternate text">
-<meta property="twitter:player" content="http://www.example.com/player.iframe">
-<meta property="twitter:player:width" content="1920">
-<meta property="twitter:player:height" content="1080">
+<meta name="twitter:card" content="player">
+<meta name="twitter:title" content="Title | Example">
+<meta name="twitter:description" content="Description">
+<meta name="twitter:site" content="@astrotomic_oss">
+<meta name="twitter:image" content="http://www.example.com/image1.jpg">
+<meta name="twitter:image:alt" content="Image alternate text">
+<meta name="twitter:player" content="http://www.example.com/player.iframe">
+<meta name="twitter:player:width" content="1920">
+<meta name="twitter:player:height" content="1080">
 </head></html>

--- a/tests/__snapshots__/TwitterTypesTest__it_can_generate_summary_tags__1.html
+++ b/tests/__snapshots__/TwitterTypesTest__it_can_generate_summary_tags__1.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><head>
-<meta property="twitter:card" content="summary">
-<meta property="twitter:title" content="Title | Example">
-<meta property="twitter:description" content="Description">
-<meta property="twitter:site" content="@astrotomic_oss">
-<meta property="twitter:image" content="http://www.example.com/image1.jpg">
-<meta property="twitter:image:alt" content="Image alternate text">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Title | Example">
+<meta name="twitter:description" content="Description">
+<meta name="twitter:site" content="@astrotomic_oss">
+<meta name="twitter:image" content="http://www.example.com/image1.jpg">
+<meta name="twitter:image:alt" content="Image alternate text">
 </head></html>

--- a/tests/__snapshots__/TwitterTypesTest__it_can_generate_summary_with_large_image_tags__1.html
+++ b/tests/__snapshots__/TwitterTypesTest__it_can_generate_summary_with_large_image_tags__1.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
 <html><head>
-<meta property="twitter:card" content="summary_large_image">
-<meta property="twitter:title" content="Title | Example">
-<meta property="twitter:description" content="Description">
-<meta property="twitter:site" content="@astrotomic_oss">
-<meta property="twitter:creator" content="@devgummibeer">
-<meta property="twitter:image" content="http://www.example.com/image1.jpg">
-<meta property="twitter:image:alt" content="Image alternate text">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Title | Example">
+<meta name="twitter:description" content="Description">
+<meta name="twitter:site" content="@astrotomic_oss">
+<meta name="twitter:creator" content="@devgummibeer">
+<meta name="twitter:image" content="http://www.example.com/image1.jpg">
+<meta name="twitter:image:alt" content="Image alternate text">
 </head></html>


### PR DESCRIPTION
This PR fixes the Twitter meta tags prefix from 'property' to 'name'.

Any suggestions and edits will help me learn open source more!!

fixes: #16 